### PR TITLE
1.2.0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -367,7 +367,7 @@ CLP.prototype.displayHelp = function () {
  * @return {String} The version information.
  */
 CLP.prototype.displayVersion = function () {
-    return this.opts.exe + " " + this.opts.version;
+    return this.opts.name + " " + this.opts.version;
 };
 
 CLP.Option = Option;


### PR DESCRIPTION
 - Fixed #5. Use the `name` field instead of `exe` in version info